### PR TITLE
Extend meta-ivi-test with a test that generates CAPI code during build

### DIFF
--- a/meta-ivi-test/recipes-extended/common-api/capicxx-core-native_3.1.5p2.bb
+++ b/meta-ivi-test/recipes-extended/common-api/capicxx-core-native_3.1.5p2.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Common API C++ core generator"
+
+LAUNCHER_BASE = "commonapi-generator"
+LAUNCHER_LINK = "capicxx-core-gen"
+
+require capicxx-native.inc
+
+SRC_URI = "${BASE_URL}/generator/${BASE_VER}/${PV}/commonapi-generator.zip"
+SRC_URI[md5sum] = "c12551e8f61da944b17a22c00d3e6559"
+SRC_URI[sha256sum] = "538a923a1e596106b9f2ce0838fcf85fd81c4e09b0951c59ad2e2e72eb6d0534"

--- a/meta-ivi-test/recipes-extended/common-api/capicxx-dbus-native_3.1.5p2.bb
+++ b/meta-ivi-test/recipes-extended/common-api/capicxx-dbus-native_3.1.5p2.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Common API C++ D-Bus generator"
+
+LAUNCHER_BASE = "commonapi-dbus-generator"
+LAUNCHER_LINK = "capicxx-dbus-gen"
+
+require capicxx-native.inc
+
+SRC_URI = "${BASE_URL}/generator/${BASE_VER}/${PV}/commonapi_dbus_generator.zip"
+SRC_URI[md5sum] = "70a6f1cf7e42a94260385281a569a486"
+SRC_URI[sha256sum] = "de165298b1062951dff07d99f491c8d8a3ca3c1a087de56bc01c083cf71fa742"

--- a/meta-ivi-test/recipes-extended/common-api/capicxx-native.inc
+++ b/meta-ivi-test/recipes-extended/common-api/capicxx-native.inc
@@ -1,0 +1,45 @@
+SECTION = "devel"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = \
+    "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+BASE_URL = "http://docs.projects.genivi.org/yamaica-update-site/CommonAPI"
+BASE_VER = "${@'.'.join(d.getVar('PV', True).split('.')[0:2])}"
+
+def get_launcher_name(d):
+    BS = d.getVar('BUILD_SYS', True)
+    if BS == "x86_64-linux":
+        launcherName = "${LAUNCHER_BASE}-linux-x86_64"
+    elif BS == "i686-linux":
+        launcherName = "${LAUNCHER_BASE}-linux-x86"
+    else:
+        bb.fatal("Build system '%s' is not supported by ${PN}_${PV} recipe" % BS)
+    return launcherName
+
+LAUNCHER = "${@get_launcher_name(d)}"
+
+inherit native
+SANITY_REQUIRED_UTILITIES += "java"
+
+S = "${WORKDIR}"
+DD = "${D}${datadir}/${PN}-${PV}"
+
+do_install() {
+    install -d ${DD}
+    install -m 0644 ${S}/artifacts.xml ${DD}
+    install -m 0755 ${S}/${LAUNCHER_BASE}-linux-x86 ${DD}
+    install -m 0644 ${S}/${LAUNCHER_BASE}-linux-x86.ini ${DD}
+    install -m 0755 ${S}/${LAUNCHER_BASE}-linux-x86_64 ${DD}
+    install -m 0644 ${S}/${LAUNCHER_BASE}-linux-x86_64.ini ${DD}
+    for dir in ./configuration ./features ./plugins; do
+        for item in $(find ${dir} -name '*' -print); do
+            if [ -d ${item} ]; then
+                install -d ${DD}/${item}
+            else
+                install -m 0644 ${S}/${item} ${DD}/$(dirname ${item})
+            fi
+        done
+    done
+    install -d "${D}${bindir}"
+    ln -sf -T "${DD}/${LAUNCHER}" ${D}${bindir}/${LAUNCHER_LINK}
+}

--- a/meta-ivi-test/recipes-extended/common-api/capicxx-perf_git.bb
+++ b/meta-ivi-test/recipes-extended/common-api/capicxx-perf_git.bb
@@ -1,0 +1,34 @@
+SUMMARY = "Common API C++ test code: measure the performance of message sending"
+SECTION = "tests"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = \
+    "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+PR = "r0"
+
+SRCREV = "2eacc9d7fb76957e9a5450a559675fddf0a95ce2"
+SRC_URI = "git://github.com/GENIVI/capic-poc.git"
+S = "${WORKDIR}/git/test/capicxx-perf"
+
+DEPENDS = "common-api-c++ common-api-c++-dbus capicxx-core-native capicxx-dbus-native"
+
+inherit cmake pkgconfig
+
+EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=/usr"
+
+_installdir = "/opt/tests/${PN}"
+
+FILES_${PN} = " \
+    ${_installdir}/* \
+    "
+
+FILES_${PN}-dbg += " \
+    ${_installdir}/.debug/* \
+    "
+
+do_install_append() {
+    _DEST=${D}${_installdir}
+    install -d ${_DEST}
+    mv ${D}/usr/bin/* ${_DEST}
+    rmdir ${D}/usr/bin
+    rmdir ${D}/usr
+}

--- a/meta-ivi-test/recipes-extended/common-api/capicxx-someip-native_3.1.5p2.bb
+++ b/meta-ivi-test/recipes-extended/common-api/capicxx-someip-native_3.1.5p2.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Common API C++ SOME/IP generator"
+
+LAUNCHER_BASE = "commonapi-someip-generator"
+LAUNCHER_LINK = "capicxx-someip-gen"
+
+require capicxx-native.inc
+
+SRC_URI = "${BASE_URL}/generator/${BASE_VER}/${PV}/commonapi_someip_generator.zip"
+SRC_URI[md5sum] = "23196ec64737ea85b96aa754d17cf01c"
+SRC_URI[sha256sum] = "5135d9df40a27d29f60785db9812a65395e077b3e61f3beaa15d08c6094f8e0d"


### PR DESCRIPTION
The last two patches (4f0454f and 3c833bd) can be applied on top of c55c45f independently.  The native recipes allow using Common API C++ generators as a part of the tool chain on the build host.  They rely on pre-built generators being available through the CAPIC++ update site.

The recipe capicxx-perf builds two executables (client and server) that rely on CAPIC++ with the D-Bus backend.  It invokes the code generators during the build and can be used to [smoke-] test both the CAPIC++ runtime and tools for core and D-Bus.

The recipe capicxx-someip-native can be optionally added to support SOME/IP code generator.  It is not required by capicxx-perf, though.
