### PR TITLE
keyutils: Fix build error in arm 64bit

### DIFF
--- a/meta-ivi-bsp/recipes-support-ivi/keyutils/keyutils_%.bbappend
+++ b/meta-ivi-bsp/recipes-support-ivi/keyutils/keyutils_%.bbappend
@@ -1,0 +1,5 @@
+SRC_URI_append_arm = " file://keyutils-arm-remove-m32-m64.patch"
+SRC_URI_append_aarch64 = " file://keyutils-arm-remove-m32-m64.patch"
+SRC_URI_append_x86 = " file://keyutils_fix_x86_cflags.patch"
+SRC_URI_append_x86-64 = " file://keyutils_fix_x86-64_cflags.patch"
+SRC_URI_append_powerpc = "file://keyutils-fix-powerpc-cflags.patch"

--- a/meta-ivi/recipes-support-ivi/keyutils/keyutils_1.5.9.bb
+++ b/meta-ivi/recipes-support-ivi/keyutils/keyutils_1.5.9.bb
@@ -15,11 +15,6 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git;p
           file://keyutils_fix_library_install.patch \
           file://keyutils-fix-the-cflags-for-all-of-targets.patch \
           "
-SRC_URI_append_arm = " file://keyutils-arm-remove-m32-m64.patch"
-SRC_URI_append_x86 = " file://keyutils_fix_x86_cflags.patch"
-SRC_URI_append_x86-64 = " file://keyutils_fix_x86-64_cflags.patch"
-SRC_URI_append_powerpc = "file://keyutils-fix-powerpc-cflags.patch"
-
 S = "${WORKDIR}/git"
 
 inherit autotools


### PR DESCRIPTION
Errors in aarch64
| aarch64-poky-linux-gcc: error: unrecognized command line option '-m64'

Signed-off-by: Changhyeok Bae changhyeok.bae@gmail.com
