### PR TITLE
common-api-c++: Add dlt-daemon dependency

### DIFF
--- a/meta-ivi/recipes-extended/common-api/common-api-c++_3.1.5.bb
+++ b/meta-ivi/recipes-extended/common-api/common-api-c++_3.1.5.bb
@@ -2,20 +2,24 @@ SUMMARY = "CommonAPI"
 SECTION = "libs"
 LICENSE = "MPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
-PROVIDES = "commonapi3"
-PR = "r0"
 
-inherit autotools cmake lib_package pkgconfig
+PROVIDES = "commonapi3"
+PR = "r1"
+
+DEPENDS = "dlt-daemon"
+
+inherit cmake lib_package pkgconfig
 
 SRCREV = "77d9cdaf6acee03a1e360e0e1a3cd0b01a95b407"
-SRC_URI = "git://git.projects.genivi.org/ipc/common-api-runtime.git;protocol=http"
+
+SRC_URI = "git://git.projects.genivi.org/ipc/common-api-runtime.git;protocol=http \
+    file://0001-common-api-runtime-replace-hard-coded-lib-dir-by-var.patch \
+    "
 S = "${WORKDIR}/git"
 
-EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=/usr"
+EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=/usr \
+    -DINSTALL_LIB_DIR:PATH=${baselib} \
+    -DINSTALL_CMAKE_DIR:PATH=${baselib}/cmake/CommonAPI \
+    "
 
 FILES_${PN}-dev += "${libdir}/cmake"
-RDEPENDS_${PN} += "dlt-daemon"
-
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI += "file://0001-common-api-runtime-replace-hard-coded-lib-dir-by-var.patch"
-EXTRA_OECMAKE += "-DINSTALL_LIB_DIR:PATH=${baselib} -DINSTALL_CMAKE_DIR:PATH=${baselib}/cmake/CommonAPI"


### PR DESCRIPTION
Change dlt-daemon runtime dependency to build dependency
because of build error.

Signed-off-by: Changhyeok Bae changhyeok.bae@gmail.com
