### PR TITLE
gstreamer: fix gst 1.2.3 support

### DIFF
--- a/meta-ivi/recipes-multimedia/gstreamer/gst-plugins-package_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gst-plugins-package_1.2.3.inc
@@ -1,0 +1,56 @@
+PACKAGESPLITFUNCS_prepend = " split_gstreamer10_packages "
+PACKAGESPLITFUNCS_append = " set_metapkg_rdepends "
+
+python split_gstreamer10_packages () {
+    gst_libdir = d.expand('${libdir}/gstreamer-${LIBV}')
+    postinst = d.getVar('plugin_postinst', True)
+    glibdir = d.getVar('libdir', True)
+
+    do_split_packages(d, glibdir, '^lib(.*)\.so\.*', 'lib%s', 'gstreamer %s library', extra_depends='', allow_links=True)
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.so$', d.expand('${PN}-%s'), 'GStreamer plugin for %s', postinst=postinst, extra_depends=d.expand('${PN}'))
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.la$', d.expand('${PN}-%s-dev'), 'GStreamer plugin for %s (development files)', extra_depends=d.expand('${PN}-dev'))
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.a$', d.expand('${PN}-%s-staticdev'), 'GStreamer plugin for %s (static development files)', extra_depends=d.expand('${PN}-staticdev'))
+}
+
+python set_metapkg_rdepends () {
+    import os
+
+    pn = d.getVar('PN', True)
+    metapkg =  pn + '-meta'
+    d.setVar('ALLOW_EMPTY_' + metapkg, "1")
+    d.setVar('FILES_' + metapkg, "")
+    blacklist = [ pn, pn + '-locale', pn + '-dev', pn + '-dbg', pn + '-doc', pn + '-meta' ]
+    metapkg_rdepends = []
+    packages = d.getVar('PACKAGES', True).split()
+    pkgdest = d.getVar('PKGDEST', True)
+    for pkg in packages[1:]:
+        if not pkg in blacklist and not pkg in metapkg_rdepends and not pkg.endswith('-dev') and not pkg.endswith('-dbg') and not pkg.count('locale') and not pkg.count('-staticdev'):
+            # See if the package is empty by looking at the contents of its PKGDEST subdirectory. 
+            # If this subdirectory is empty, then the package is.
+            # Empty packages do not get added to the meta package's RDEPENDS
+            pkgdir = os.path.join(pkgdest, pkg)
+            if os.path.exists(pkgdir):
+                dir_contents = os.listdir(pkgdir) or []
+            else:
+                dir_contents = []
+            is_empty = len(dir_contents) == 0
+            if not is_empty:
+                metapkg_rdepends.append(pkg)
+    d.setVar('RDEPENDS_' + metapkg, ' '.join(metapkg_rdepends))
+    d.setVar('DESCRIPTION_' + metapkg, pn + ' meta package')
+}
+
+# metapkg has runtime dependency on PN
+# each plugin depends on PN, plugin-dev on PN-dev, plugin-staticdev on PN-staticdev
+# so we need them even when empty (like in gst-plugins-good case)
+ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY_${PN}-dev = "1"
+ALLOW_EMPTY_${PN}-staticdev = "1"
+
+PACKAGES += "${PN}-apps ${PN}-meta ${PN}-glib"
+FILES_${PN}-apps = "${bindir}"
+
+FILES_${PN} = "${datadir}/gstreamer-${LIBV}"
+FILES_${PN}-dbg += "${libdir}/gstreamer-${LIBV}/.debug"
+FILES_${PN}-glib = "${datadir}/glib-2.0"
+

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.0.0.bb
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.0.0.bb
@@ -1,6 +1,6 @@
 DEFAULT_PREFERENCE = "-1"
 
-include recipes-multimedia/gstreamer/gstreamer1.0-omx.inc
+include recipes-multimedia/gstreamer/gstreamer1.0-omx_1.0.0.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
                     file://omx/gstomx.h;beginline=1;endline=21;md5=5c8e1fca32704488e76d2ba9ddfa935f"

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.0.0.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.0.0.inc
@@ -1,0 +1,42 @@
+SUMMARY = "OpenMAX IL plugins for GStreamer"
+SECTION = "multimedia"
+LICENSE = "LGPLv2.1"
+LICENSE_FLAGS = "commercial"
+HOMEPAGE = "http://www.gstreamer.net/"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
+RDEPENDS_${PN} = "libomxil"
+
+inherit autotools pkgconfig gettext
+
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+PR = "r1"
+
+GSTREAMER_1_0_OMX_TARGET ?= "bellagio"
+GSTREAMER_1_0_OMX_CORE_NAME ?= "/usr/lib/libomxil-bellagio.so.0"
+
+EXTRA_OECONF += "--disable-valgrind --disable-introspection --with-omx-target=${GSTREAMER_1_0_OMX_TARGET}"
+
+python __anonymous () {
+    omx_target = d.getVar("GSTREAMER_1_0_OMX_TARGET", True)
+    if omx_target in ['generic', 'bellagio']:
+        srcdir = d.getVar("S", True)
+        # Bellagio headers are incomplete (they are missing the OMX_VERSION_MAJOR,#
+        # OMX_VERSION_MINOR, OMX_VERSION_REVISION, and OMX_VERSION_STEP macros);
+        # appending a directory path to gst-omx' internal OpenMAX IL headers fixes this
+        d.appendVar("CFLAGS", " -I%s/omx/openmax" % srcdir)
+    elif omx_target == "rpi":
+        # Dedicated Raspberry Pi OpenMAX IL support makes this package machine specific
+        d.setVar("PACKAGE_ARCH", d.getVar("MACHINE_ARCH", True))
+}
+
+set_omx_core_name() {
+	sed -i -e "s;^core-name=.*;core-name=${GSTREAMER_1_0_OMX_CORE_NAME};" "${D}/etc/xdg/gstomx.conf"
+}
+do_install[postfuncs] += " set_omx_core_name "
+
+FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dbg += "${libdir}/gstreamer-1.0/.debug"
+FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la"
+FILES_${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
+

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.bb
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.bb
@@ -1,6 +1,6 @@
 DEFAULT_PREFERENCE = "-1"
 
-include recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
+include recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.inc
 
 #remove patch from poky that is not necessary in version 1.2.3
 SRC_URI_remove = "file://configure-allow-to-disable-libssh2.patch"

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.inc
@@ -1,0 +1,121 @@
+require gstreamer1.0-plugins_1.2.3.inc
+
+LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+ "
+
+DEPENDS += "gstreamer1.0-plugins-base bzip2"
+
+S = "${WORKDIR}/gst-plugins-bad-${PV}"
+
+inherit gettext bluetooth
+
+
+PACKAGECONFIG ??= " \
+    ${@base_contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \
+    ${@base_contains('DISTRO_FEATURES', 'opengl', 'eglgles', '', d)} \
+    ${@base_contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)} \
+    ${@base_contains('DISTRO_FEATURES', 'directfb', 'directfb', '', d)} \
+    orc curl uvch264 neon \
+    hls sbc dash bz2 smoothstreaming \
+    "
+# dash = Dynamic Adaptive Streaming over HTTP
+PACKAGECONFIG[assrender]       = "--enable-assrender,--disable-assrender,libass"
+PACKAGECONFIG[curl]            = "--enable-curl,--disable-curl,curl"
+PACKAGECONFIG[eglgles]         = "--enable-eglgles,--disable-eglgles,virtual/egl virtual/libgles2"
+PACKAGECONFIG[faac]            = "--enable-faac,--disable-faac,faac"
+PACKAGECONFIG[faad]            = "--enable-faad,--disable-faad,faad2"
+PACKAGECONFIG[libmms]          = "--enable-libmms,--disable-libmms,libmms"
+PACKAGECONFIG[modplug]         = "--enable-modplug,--disable-modplug,libmodplug"
+PACKAGECONFIG[mpg123]          = "--enable-mpg123,--disable-mpg123,mpg123"
+PACKAGECONFIG[opus]            = "--enable-opus,--disable-opus,libopus"
+PACKAGECONFIG[flite]           = "--enable-flite,--disable-flite,flite-alsa"
+PACKAGECONFIG[opencv]          = "--enable-opencv,--disable-opencv,opencv"
+PACKAGECONFIG[wayland]         = "--enable-wayland,--disable-wayland,wayland"
+PACKAGECONFIG[uvch264]         = "--enable-uvch264,--disable-uvch264,libusb1 udev"
+PACKAGECONFIG[directfb]        = "--enable-directfb,--disable-directfb,directfb"
+PACKAGECONFIG[neon]            = "--enable-neon,--disable-neon,neon"
+PACKAGECONFIG[openal]          = "--enable-openal,--disable-openal,openal-soft"
+PACKAGECONFIG[hls]             = "--enable-hls,--disable-hls,gnutls"
+PACKAGECONFIG[sbc]             = "--enable-sbc,--disable-sbc,sbc"
+PACKAGECONFIG[dash]            = "--enable-dash,--disable-dash,libxml2"
+PACKAGECONFIG[bz2]             = "--enable-bz2,--disable-bz2,bzip2"
+PACKAGECONFIG[fluidsynth]      = "--enable-fluidsynth,--disable-fluidsynth,fluidsynth"
+PACKAGECONFIG[schroedinger]    = "--enable-schro,--disable-schro,schroedinger"
+PACKAGECONFIG[smoothstreaming] = "--enable-smoothstreaming,--disable-smoothstreaming,libxml2"
+PACKAGECONFIG[bluez]          = "--enable-bluez,--disable-bluez,${BLUEZ}"
+PACKAGECONFIG[rsvg]            = "--enable-rsvg,--disable-rsvg,librsvg"
+
+# these plugins have not been ported to 1.0 (yet):
+#   directdraw vcd apexsink cdaudio dc1394 lv2 linsys musepack mythtv
+#   nas timidity teletextdec sdl sndfile xvid wininet acm gsettings
+#   sndio cdxaparse dccp faceoverlay hdvparse ivfparse jp2kdecimator
+#   linsys mve nuvdemux osx_video patchdetect quicktime real sdi stereo
+#   tta videomeasure videosignal vmnc
+
+EXTRA_OECONF += " \
+    --enable-dvb \
+    --enable-shm \
+    --enable-mfc \
+    --enable-fbdev \
+    --enable-decklink \
+    --disable-acm \
+    --disable-android_media \
+    --disable-apexsink \
+    --disable-apple_media \
+    --disable-avc \
+    --disable-cdaudio \
+    --disable-chromaprint \
+    --disable-daala \
+    --disable-dc1394 \
+    --disable-direct3d \
+    --disable-directdraw \
+    --disable-directshow \
+    --disable-directsound \
+    --disable-dts \
+    --disable-gme \
+    --disable-gsettings \
+    --disable-gsm \
+    --disable-kate \
+    --disable-ladspa \
+    --disable-linsys \
+    --disable-lv2 \
+    --disable-mimic \
+    --disable-mpeg2enc \
+    --disable-mplex \
+    --disable-musepack \
+    --disable-mythtv \
+    --disable-nas \
+    --disable-ofa \
+    --disable-openjpeg \
+    --disable-opensles \
+    --disable-osx_video \
+    --disable-pvr \
+    --disable-quicktime \
+    --disable-resindvd \
+    --disable-rtmp \
+    --disable-sdl \
+    --disable-sdltest \
+    --disable-sndfile \
+    --disable-sndio \
+    --disable-soundtouch \
+    --disable-spandsp \
+    --disable-spc \
+    --disable-srtp \
+    --disable-teletextdec \
+    --disable-timidity \
+    --disable-vcd \
+    --disable-vdpau \
+    --disable-voaacenc \
+    --disable-voamrwbenc \
+    --disable-wasapi \
+    --disable-webp \
+    --disable-wildmidi \
+    --disable-wininet \
+    --disable-winscreencap \
+    --disable-xvid \
+    --disable-zbar \
+    ${GSTREAMER_1_0_ORC} \
+    --disable-introspection \
+    "
+
+ARM_INSTRUCTION_SET = "arm"
+

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.bb
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.bb
@@ -1,6 +1,6 @@
 DEFAULT_PREFERENCE = "-1"
 
-include recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
+include recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=c54ce9345727175ff66d17b67ff51f58 \
                     file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607 \

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.inc
@@ -1,0 +1,40 @@
+require gstreamer1.0-plugins_1.2.3.inc
+
+LICENSE = "GPLv2+ & LGPLv2+"
+
+DEPENDS += "${@base_contains('DISTRO_FEATURES', 'x11', 'virtual/libx11 libxv', '', d)}"
+DEPENDS += "freetype liboil util-linux"
+
+inherit gettext
+
+PACKAGES_DYNAMIC =+ "^libgst.*"
+
+PACKAGECONFIG ??= " \
+    ${@base_contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    ${@base_contains('DISTRO_FEATURES', 'alsa', 'alsa', '', d)} \
+    orc ivorbis ogg theora vorbis \
+    "
+
+X11DEPENDS = "virtual/libx11 libsm libxrender"
+X11ENABLEOPTS = "--enable-x --enable-xvideo --enable-xshm"
+X11DISABLEOPTS = "--disable-x --disable-xvideo --disable-xshm"
+PACKAGECONFIG[x11]     = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+PACKAGECONFIG[alsa]    = "--enable-alsa,--disable-alsa,alsa-lib"
+PACKAGECONFIG[ivorbis] = "--enable-ivorbis,--disable-ivorbis,tremor"
+PACKAGECONFIG[ogg]     = "--enable-ogg,--disable-ogg,libogg"
+PACKAGECONFIG[theora]  = "--enable-theora,--disable-theora,libtheora"
+PACKAGECONFIG[vorbis]  = "--enable-vorbis,--disable-vorbis,libvorbis"
+PACKAGECONFIG[pango]   = "--enable-pango,--disable-pango,pango"
+
+
+# cdparanoia and libvisual do not seem to exist anywhere in OE
+EXTRA_OECONF += " \
+    --disable-freetypetest \
+    --disable-cdparanoia \
+    --disable-libvisual \
+    ${GSTREAMER_1_0_ORC} \
+    --disable-introspection \
+"
+
+FILES_${PN} += "${datadir}/gst-plugins-base"
+

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.2.3.bb
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.2.3.bb
@@ -1,6 +1,6 @@
 DEFAULT_PREFERENCE = "-1"
 
-include recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
+include recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.2.3.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607 \

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.2.3.inc
@@ -1,0 +1,56 @@
+require gstreamer1.0-plugins_1.2.3.inc
+
+LICENSE = "GPLv2+ & LGPLv2.1+"
+
+# libid3tag
+DEPENDS += "gstreamer1.0-plugins-base zlib bzip2"
+
+inherit gettext
+
+
+PACKAGECONFIG ??= " \
+    ${@base_contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    ${@base_contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)} \
+    orc cairo flac gdk-pixbuf jpeg libpng soup speex taglib \
+    "
+
+X11DEPENDS = "virtual/libx11 libsm libxrender libxfixes libxdamage"
+X11ENABLEOPTS = "--enable-x --enable-xvideo --enable-xshm"
+X11DISABLEOPTS = "--disable-x --disable-xvideo --disable-xshm"
+PACKAGECONFIG[x11]        = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+PACKAGECONFIG[pulseaudio] = "--enable-pulse,--disable-pulse,pulseaudio"
+PACKAGECONFIG[cairo]      = "--enable-cairo,--disable-cairo,cairo"
+PACKAGECONFIG[flac]       = "--enable-flac,--disable-flac,flac"
+PACKAGECONFIG[gdk-pixbuf] = "--enable-gdk_pixbuf,--disable-gdk_pixbuf,gdk-pixbuf"
+PACKAGECONFIG[jack]       = "--enable-jack,--disable-jack,jack"
+PACKAGECONFIG[jpeg]       = "--enable-jpeg,--disable-jpeg,jpeg"
+PACKAGECONFIG[libpng]     = "--enable-libpng,--disable-libpng,libpng"
+PACKAGECONFIG[soup]       = "--enable-soup,--disable-soup,libsoup-2.4"
+PACKAGECONFIG[speex]      = "--enable-speex,--disable-speex,speex"
+PACKAGECONFIG[taglib]     = "--enable-taglib,--disable-taglib,taglib"
+PACKAGECONFIG[vpx]        = "--enable-vpx,--disable-vpx,libvpx"
+PACKAGECONFIG[wavpack]    = "--enable-wavpack,--disable-wavpack,wavpack"
+
+# the 1394 plugins require both libraw1394 and libiec61883
+# the former is included in meta-oe, the latter isn't
+# -> disabled
+
+EXTRA_OECONF += " \
+    --enable-oss \
+    --enable-gst_v4l2 \
+    --without-libv4l2 \
+    --disable-directsound \
+    --disable-waveform \
+    --disable-oss4 \
+    --disable-sunaudio \
+    --disable-osx_audio \
+    --disable-osx_video \
+    --disable-aalib \
+    --disable-libcaca \
+    --disable-libdv \
+    --disable-shout2 \
+    --disable-examples \
+    --disable-dv1394 \
+    ${GSTREAMER_1_0_ORC} \
+"
+

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.2.3.bb
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.2.3.bb
@@ -1,6 +1,6 @@
 DEFAULT_PREFERENCE = "-1"
 
-include recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc
+include recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.2.3.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068 "

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.2.3.inc
@@ -1,0 +1,31 @@
+require gstreamer1.0-plugins_1.2.3.inc
+
+LICENSE = "GPLv2+ & LGPLv2.1+ & LGPLv2+"
+LICENSE_FLAGS = "commercial"
+
+DEPENDS += "gstreamer1.0-plugins-base libid3tag"
+
+inherit gettext
+
+
+PACKAGECONFIG ??= " \
+    orc a52dec lame mad mpeg2dec \
+    "
+
+PACKAGECONFIG[a52dec]   = "--enable-a52dec,--disable-a52dec,liba52"
+PACKAGECONFIG[cdio]     = "--enable-cdio,--disable-cdio,libcdio"
+PACKAGECONFIG[dvdread]  = "--enable-dvdread,--disable-dvdread,libdvdread"
+PACKAGECONFIG[lame]     = "--enable-lame,--disable-lame,lame"
+PACKAGECONFIG[mad]      = "--enable-mad,--disable-mad,libmad"
+PACKAGECONFIG[mpeg2dec] = "--enable-mpeg2dec,--disable-mpeg2dec,mpeg2dec"
+PACKAGECONFIG[x264]     = "--enable-x264,--disable-x264,x264"
+
+
+EXTRA_OECONF += " \
+    --disable-amrnb \
+    --disable-amrwb \
+    --disable-sidplay \
+    --disable-twolame \
+    ${GSTREAMER_1_0_ORC} \
+    "
+

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins_1.2.3.inc
@@ -1,0 +1,59 @@
+SUMMARY = "Plugins for the GStreamer multimedia framework 1.x"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+DEPENDS = "gstreamer1.0"
+
+inherit autotools pkgconfig
+
+FILESPATH =. "${FILE_DIRNAME}/gst-plugins:"
+
+GSTREAMER_1_0_DEBUG ?= "--disable-debug"
+GSTREAMER_1_0_GIT_BRANCH ?= "master"
+EXTRA_OECONF = "--disable-valgrind ${GSTREAMER_1_0_DEBUG} --disable-examples "
+
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+LIBV = "1.0"
+require gst-plugins-package_1.2.3.inc
+
+PACKAGECONFIG[orc] = "--enable-orc,--disable-orc,orc"
+
+PACKAGES_DYNAMIC = "^${PN}-.*"
+
+# apply gstreamer hack after Makefile.in.in in source is replaced by our version from
+# ${STAGING_DATADIR_NATIVE}/gettext/po/Makefile.in.in, but before configure is executed 
+# http://lists.linuxtogo.org/pipermail/openembedded-core/2012-November/032233.html
+oe_runconf_prepend() {
+	if [ -e ${S}/po/Makefile.in.in ]; then
+		sed -i -e "1a\\" -e 'GETTEXT_PACKAGE = @GETTEXT_PACKAGE@' ${S}/po/Makefile.in.in
+	fi
+}
+
+SRC_URI = "${@get_gst_srcuri(d)}"
+
+def get_gst_srcuri(d):
+    # check if expected prefix is present
+    prefix = "gstreamer1.0-"
+    bpn = d.getVar("BPN", True)
+    if not bpn.startswith(prefix):
+        bb.fatal('Invalid GStreamer 1.0 plugin package name "%s" : must start with "%s"' % (bpn, prefix))
+
+    # replaced prefix with "gst-", which is what is used for the tarball and repository filenames
+    gstpkg_basename = "gst-" + bpn[len(prefix):]
+    pv = d.getVar("PV", True)
+    branch = d.getVar("GSTREAMER_1_0_GIT_BRANCH", True)
+
+    if pv == "git":
+        s = "git://anongit.freedesktop.org/gstreamer/%s;branch=%s" % (gstpkg_basename, branch)
+    else:
+        s = "http://gstreamer.freedesktop.org/src/%s/%s-%s.tar.xz" % (gstpkg_basename, gstpkg_basename, pv)
+    return s
+
+delete_liblink_m4_file() {
+	# This m4 file contains nastiness which conflicts with libtool 2.2.2
+	rm "${S}/m4/lib-link.m4" || true
+}
+
+do_configure[prefuncs] += " delete_liblink_m4_file "
+

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.bb
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.bb
@@ -1,6 +1,6 @@
 DEFAULT_PREFERENCE = "-1"
 
-include recipes-multimedia/gstreamer/gstreamer1.0.inc
+include recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
                     file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.inc
@@ -1,0 +1,28 @@
+SUMMARY = "GStreamer 1.0 multimedia framework"
+DESCRIPTION = "GStreamer is a multimedia framework for encoding and decoding video and sound. \
+It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime."
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+LICENSE = "LGPLv2+"
+DEPENDS = "glib-2.0 libxml2 bison-native flex-native"
+
+inherit autotools pkgconfig gettext
+
+GSTREAMER_1_DEBUG ?= "--disable-debug"
+EXTRA_OECONF = "--disable-docbook --disable-gtk-doc \
+                --disable-dependency-tracking --disable-check \
+                --disable-examples --disable-tests \
+                --disable-valgrind ${GSTREAMER_1_DEBUG} \
+                --disable-introspection \
+                "
+
+RRECOMMENDS_${PN}_qemux86    += "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
+RRECOMMENDS_${PN}_qemux86-64 += "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
+
+CACHED_CONFIGUREVARS += "ac_cv_header_valgrind_valgrind_h=no"
+
+FILES_${PN} += " ${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dev += " ${libdir}/gstreamer-1.0/*.la ${libdir}/gstreamer-1.0/*.a"
+FILES_${PN}-dbg += " ${libdir}/gstreamer-1.0/.debug/ ${libexecdir}/gstreamer-1.0/.debug/"
+


### PR DESCRIPTION
meta-ivi carries gst 1.2.3 support (as well as supporting
 the later versions used by poky meta) as the last survey
within genivi showed that various silicon vendors used it
in their BSPs, R-Car Gen 2 included. The move to yp 2.1
(krogoth) has exposed some gaps in that support. The recipes
include some files that were not renamed. Fix that now by
adding the missing files (renamed to have a _1.2.3 suffix)
and modify the gst 1.2.3 recipes to use them.
