### PR TITLE
Fix build issue with java versions other than 1.8

### DIFF
--- a/meta-ivi/recipes-extended/common-api/capicxx-native.inc
+++ b/meta-ivi/recipes-extended/common-api/capicxx-native.inc
@@ -26,7 +26,7 @@ DD = "${D}${datadir}/${PN}-${PV}"
 
 do_install() {
     # work around for java-8
-    java_version=`java -version 2>&1 | head -n 1 | grep '[ "]1\.8[\. "$$]'`
+    java_version=`java -version 2>&1 | head -n 1 | grep { '[ "]1\.8[\. "$$]' || true; }`
     if [ "x${java_version}" != "x" ]; then
       for i in x86 x86_64; do
         perl -pi -e 's|-XX:PermSize=128m||' ${S}/${LAUNCHER_BASE}-linux-${i}.ini


### PR DESCRIPTION
[GDP-398] bitbake was spotting that grep was returning 1
This commit avoids that issue
