### PR TITLE
Remove baseline_ci_helper and include checkout script in meta-ivi/scripts instead

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,28 @@
+# Scripts
+
+## checkout_layer_hash.sh
+
+A build helper for meta-ivi.
+
+This script extract the revision information for dependent layers (poky
+and meta-openembedded) from the README of meta-ivi so that automated builds
+are possible.
+
+Usage:
+
+Run in meta-ivi repository root (meta-ivi, not meta-ivi/meta-ivi).
+The script assumes you have cloned poky and meta-openembedded inside
+meta-ivi root which is normally not the case in a full system build - 
+then meta-ivi is in parallel with all other layers, but when building
+the baseline only, we assume the build happens inside of meta-ivi dir.
+
+
+Example:
+$ cd meta-ivi 
+   (the first one)
+$ checkout_layer_hash.sh poky
+$ checkout_layer_hash.sh meta-openembedded
+
+## Other scripts
+
+* See README.md in project root

--- a/scripts/checkout_layer_hash.sh
+++ b/scripts/checkout_layer_hash.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# (C) Gunnar Andersson 2015-12-12
+# License: MPLv2
+
+# This fetches information about layer dependencies
+# as documented in meta-ivi README.
+# revision, branch name, or sub layer name can be extracted
+
+README=README.md
+DEBUG=false
+
+
+fail() {
+   echo "*** FAILED ***"
+   [ -n "$1" ] && echo "Message: " $@
+   exit 1
+}
+
+sanity_check_num_lines() {
+   what=$1 ; min=$2 ; max=$3
+
+   numlines="$(wc -l)" # < Reads from stdin
+
+   if [ $numlines -lt $min ] ; then 
+      fail "Sanity check: It looks like section $what has $numlines lines, and that is not enough.  Please check what is wrong."
+   fi
+
+   if [ $numlines -gt $max ] ; then
+      fail "Sanity check: It looks like section $what has $numlines lines, and that is more than expected.  Please check what is wrong."
+   fi
+}
+
+[ -f ./$README ] || fail "Cannot find README.md.  (Current directory is $PWD)"
+
+get_layer_info() {
+   layer=$1
+   what=$2
+
+   # Example README format:
+   #
+   #Layer Dependencies
+   #------------------
+   #
+   #URI: git://git.yoctoproject.org/poky
+   #> branch:   fido
+   #> revision: eb4a134a60e3ac26a48379675ad6346a44010339
+   #
+   #URI: git://git.openembedded.org/meta-openembedded
+   #> layer:    meta-oe
+   #> branch:   fido
+   #> revision: 5b0305d9efa4b5692cd942586fb7aa92dba42d59
+
+   # Extract relevant section of the README
+   dependency_section=$( <$README \
+      sed -n '/Layer Dependencies/,/known to work/p' |\
+      egrep 'URI:|branch:|layer:|revision:')
+
+   # Debug printouts...
+   $DEBUG && echo "OK, found the following layer info in dependency section:"
+   $DEBUG && cat <<EOT
+   $dependency_section
+EOT
+
+   cat <<EOT | sanity_check_num_lines "Layer Dependencies Section" 6 20
+   $dependency_section
+EOT
+
+   # Get only this layer's information
+   layer_info=$(
+   cat <<EOT | sed -n "/URI:.*$layer/,/URI:/p" | sed 's/> //' | head -4
+   $dependency_section
+EOT
+   )
+
+   # Get value for item "what" (what = revision, branch, ...)
+   value=$(
+   cat <<EOT | grep "$what" | awk '{print $2}'
+   $layer_info
+EOT
+   )
+
+   # Check again - now only one line expected...
+   cat <<EOT | sanity_check_num_lines "$what information for $layer" 1 1
+   $value
+EOT
+
+   # OK, this should be it
+   echo $value
+
+}
+
+checkoutlayer=$1
+[ -z "$checkoutlayer" ] && { echo "Usage: $0 <layername, e.g. poky>" ; exit 1 ; }
+
+# Extract revision from README in meta-ivi
+revision=$(get_layer_info $checkoutlayer revision)
+
+# Fail if we could not fetch revision
+[ -z "$revision" ] && fail "Revision extracted from README was empty"
+
+# Checkout the right revision in this layer.  We expect the layer, e.g.
+# poky to be found inside the root of meta-ivi, that is the $PWD when
+# this script is run.  (Not true on full system builds, but typically
+# when building baseline only)
+cd "$checkoutlayer" || fail "Can't cd to layer directory ($checkoutlayer)"
+git checkout $revision
+


### PR DESCRIPTION
meta-ivi does not include any "init.sh" like GDP and it also does not use submodules like GDP.  Instead there are manual steps described in the README.

To make the build automatic, we must extract the right commit hash from the README, for poky and for meta-openembedded.

I have previously created https://github.com/genivi/baseline_ci_helper to be able to automate the build in https://go.genivi.org.  

1. ...but those scripts seem useful to all users of meta-ivi.  
2. Also, meta-ivi already has a scripts/ directory we can use.
3. Also, it is better to not have too many repositories on GitHub. (@jeremiah)  So after this we could maybe remove the baseline_ci_helper from GitHub.

Therefore I propose to include this in meta-ivi.

I also have an init.sh script that will execute these checkouts.  I can add this if you want - then it will be very similar to GDP - only one setup script necessary.
