### PR TITLE
[BASE-37] persistence-client-library: Update to latest commits on GitHub

### DIFF
--- a/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.1.0.bb
+++ b/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.1.0.bb
@@ -2,22 +2,26 @@ SUMMARY = "GENIVI Persistence Client Library"
 DESCRIPTION = "The Persistence Management is responsible to handle \
     persistent data, including all data read and modified often during \
     a lifetime of an infotainment system."
-HOMEPAGE = "http://projects.genivi.org/persistence-client-library"
-BUGTRACKER = "http://bugs.genivi.org/enter_bug.cgi?product=Persistence"
+HOMEPAGE = "https://at.projects.genivi.org/wiki/display/PROJ/Persistence+Client+Library"
+BUGTRACKER = "https://at.projects.genivi.org/jira/browse/PCL"
 LICENSE = "MPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6161c6840f21a000e9b52af81d2ca823"
 
 DEPENDS = "dlt-daemon dbus libcheck persistence-common-object"
 
-SRCREV = "fe4b73dcc282932ae3ebb8805e0b617a0016dc9a"
+SRCREV = "18e5dde1dd0d2dd61460cc27257b8a51f66f75b6"
 SRC_URI = " \
-    git://git.projects.genivi.org/persistence/persistence-client-library.git;protocol=http \
+    git://github.com/GENIVI/${BPN}.git;protocol=https \
     file://0001-load-correct-version-of-libpers_common.patch \
     file://0001-fix-exec-path.patch \
     "
 S = "${WORKDIR}/git"
 
+PR = "r2"
+
 inherit pkgconfig autotools-brokensep
+
+EXTRA_OECONF_append = "--enable-tools"
 
 PARALLEL_MAKE = ""
 


### PR DESCRIPTION
Summary:

* Update references after migration of upstream source from git.projects.genivi.org to GitHub
* Build the PCL tools (by specifying the --enable-tools option to configure)

Details at https://at.projects.genivi.org/jira/browse/BASE-37

Signed-off-by: Gianpaolo Macario <gianpaolo_macario@mentor.com>