### PR TITLE
capicxx native symbolic link issue

### DIFF
--- a/meta-ivi/recipes-extended/common-api/capicxx-native.inc
+++ b/meta-ivi/recipes-extended/common-api/capicxx-native.inc
@@ -49,5 +49,5 @@ do_install() {
         done
     done
     install -d "${D}${bindir}"
-    ln -sf -T "${DD}/${LAUNCHER}" ${D}${bindir}/${LAUNCHER_LINK}
+    ln -sf -T ../.."${datadir_native}/${PN}-${PV}/${LAUNCHER}" ${D}${bindir}/${LAUNCHER_LINK}
 }


### PR DESCRIPTION
@tolkien-joh 

currently capicxx-core-gen and capicxx-dbus-gen in native sysroot (tmp/sysroots/x86_64-linux/usr/bin) symbolic link is link with absolute path to WORKDIR (tmp/work/tmp/work/x86_64-linux/capicxx*-native). It will be broken while using INHERIT += "rm_work".

This PR change the symbolic path. Please check it. Thanks.