### PR TITLE
wayland-ivi-extension: Update LIC_FILES_CHKSUM

### DIFF
--- a/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_1.11.0.bb
+++ b/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_1.11.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "GENIVI Layer Management API based on Wayland IVI Extension"
 HOMEPAGE = "http://projects.genivi.org/wayland-ivi-extension"
 BUGTRACKER = "http://bugs.genivi.org/enter_bug.cgi?product=Wayland%20IVI%20Extension"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=176cedb32f48dd58f07e0c1c717b3ea4"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 
 PR = "r0"
 


### PR DESCRIPTION
Update md5sum hash for avoiding license-checksum
warning of Yocto QA checking

Signed-off-by: Phong Tran <tranmanphong@gmail.com>