### PR TITLE
poky-ivi-systemd.conf: enable aarch64 for qemu-native

### DIFF
--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -36,7 +36,7 @@ DISTRO_EXTRA_RDEPENDS_append_vexpressa9 = " ${POKYQEMUDEPS}"
 
 TCLIBCAPPEND = ""
 
-QEMU_TARGETS ?= "arm i386 x86_64"
+QEMU_TARGETS ?= "arm aarch64 i386 x86_64"
 
 XSERVER ?= "xserver-xorg \
            xserver-xf86-config \


### PR DESCRIPTION
The QEMU_TARGET is lacking of aarch64 that gobject-introspection
need for g-ir-scanner-qemuwrapper.

[GDP-585] Pipeline fail for Renesas Gen3 starter kit
          build (needs qemu-aarch64?)

Signed-off-by: Phong Tran <tranmanphong@gmail.com>