### PR TITLE
The connectivity check URI needs to change

### DIFF
--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -76,7 +76,7 @@ https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n"
 
 CONNECTIVITY_CHECK_URIS ?= " \
              https://eula-downloads.yoctoproject.org/index.php \
-             http://bugs.genivi.org/report.cgi"
+             http://www.genivi.org"
 
 # Default hash policy for distro
 BB_SIGNATURE_HANDLER ?= 'OEBasicHash'


### PR DESCRIPTION
The CONNECTIVITY_CHECK_URIS variable was set to check bugs.genivi.org 
but that site is now decomissioned.  A new alternative URL is needed because now it
seems that bitbake stops working right away.

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>
