### PR TITLE
gstreamer1.0-plugins-bad: fix QA_ERROR

### DIFF
--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.bb
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.bb
@@ -12,3 +12,11 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
 SRC_URI[md5sum] = "cfd6f303c8df2740b27cc63b945decef"
 SRC_URI[sha256sum] = "595d7911a9e6207dea37200587724bdbf841b81a5eb0730118be36976684278c"
 S = "${WORKDIR}/gst-plugins-bad-${PV}"
+
+do_install_append() {
+    if ls ${D}${libdir}/pkgconfig/*.pc >/dev/null 2>/dev/null; then
+        sed -i ${D}${libdir}/pkgconfig/*.pc \
+            -e "s@-L${STAGING_LIBDIR}@-L\${libdir}@g" \
+            -e "s@${STAGING_DIR_TARGET}@@g"
+    fi
+}


### PR DESCRIPTION
This error occurs while building meta-ivi components using poky as a distro.

ERROR: QA Issue: gstreamer-egl-1.0.pc failed sanity test (tmpdir) in path build/tmp/work/corei7-64-poky-linux/gstreamer1.0-plugins-bad/1.2.3-r0/sysroot-destdir/usr/lib/pkgconfig [pkgconfig]

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>