### PR TITLE
persistence-client-library: fix QA errors

### DIFF
--- a/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.1.0.bb
+++ b/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.1.0.bb
@@ -35,6 +35,8 @@ FILES_${PN} += " \
     ${libdir}/lib*custom.so \
     ${libdir}/*.so.* \
     ${sysconfdir} \
+    /Data/mnt-c \
+    /Data/mnt-wt \
     "
 FILES_${PN}-dev += " \
     ${libdir}/libpersistence_client_library.so \


### PR DESCRIPTION
QA Issue: persistence-client-library: Files/directories were installed but not shipped in any package:
  /Data
  /Data/mnt-c
  /Data/mnt-wt
Please set FILES such that these items are packaged.
Alternatively if they are unneeded, avoid installing them or delete them within do_install.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>