### PR TITLE
wayland-ivi-extension: update to release v1.11.1

### DIFF
--- a/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_1.11.1.bb
+++ b/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_1.11.1.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 
 PR = "r0"
 
-SRCREV = "c9001582b10ce209c37b42dd560947c5aa8928b3"
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http \
+SRCREV = "8fdae4cff2647d0060174509990cd2874e1d793d"
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http;branch=1.11 \
     "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update to maintenance release v1.11.1 to fix some crashes and
memory corruption.

Change log:
8fdae4c Bump version to 1.11.1 bugfix release
0f36214 Fix crash when surface already focused
93403d5 MockNavi: fixed selection between xdg- and ivi-shell (*1)
254383a ilmControl: fix memory corruption at input listener
492f5f2 ilmControl: fix memory leak at deinitialization
a881a58 Fix ivi-application lib install
947458b ivi-share: fix compilation issue

(*1) Before the application tried to register as xdg- and ivi-shell
application.

Successfully sanity tested via GDP-12 (sha c7edb59) build for M3 Starter Kit.

Signed-off-by: Stephen Lawrence <stephen.lawrence@renesas.com>