### PR TITLE
node-state-manager: Depends on gdbus-codegen

### DIFF
--- a/meta-ivi/recipes-extended/node-state-manager/node-state-manager_2.0.0.bb
+++ b/meta-ivi/recipes-extended/node-state-manager/node-state-manager_2.0.0.bb
@@ -23,7 +23,7 @@ PR = "r2"
 
 EXTRA_OECONF = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '--with-systemdsystemunitdir=${systemd_unitdir}/system/', '', d)}"
 
-DEPENDS = "dbus glib-2.0 dlt-daemon persistence-client-library systemd"
+DEPENDS = "dbus glib-2.0 glib-2.0-native dlt-daemon persistence-client-library systemd"
 
 inherit pkgconfig autotools-brokensep systemd
 


### PR DESCRIPTION
The node-state-manager build will fail if glib-2.0-native is not stated
as an explicit dependency because the gdbus-codegen tool is not available.

| gdbus-codegen --interface-prefix=org.genivi.NodeStateManager.
--c-namespace=NodeState --generate-c-code=generated/NodeStateConsumer
--generate-docbook=doc/NodeStateConsumer
model/org.genivi.NodeStateManager.Consumer.xml
| gdbus-codegen --interface-prefix=org.genivi.NodeStateManager.
--c-namespace=NodeState
--generate-c-code=generated/NodeStateLifecycleControl
--generate-docbook=doc/LifecycleControl
model/org.genivi.NodeStateManager.LifecycleControl.xml
| gdbus-codegen --interface-prefix=org.genivi.NodeStateManager.
--c-namespace=NodeState
--generate-c-code=generated/NodeStateLifecycleConsumer
--generate-docbook=doc/LifecycleConsumer
model/org.genivi.NodeStateManager.LifecycleConsumer.xml
| /bin/bash: gdbus-codegen: command not found

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>