### PR TITLE
cairo: fix QA Issue

### DIFF
--- a/meta-ivi/recipes-graphics/cairo/cairo_%.bbappend
+++ b/meta-ivi/recipes-graphics/cairo/cairo_%.bbappend
@@ -9,8 +9,10 @@ PACKAGES_remove =+ "\
 do_install_append () {
 	rm -f ${D}${bindir}/cairo-trace
 	rm -f ${D}${libdir}/cairo/libcairo-trace.so*
-
-	rmdir ${D}${bindir}
+        rm -f ${D}${libdir}/cairo/*.la
+ 
+        rmdir ${D}${bindir}
+        rmdir ${D}${libdir}/cairo
 
 	rm -f ${D}${libdir}/libcairo-script-interpreter.so*
 }


### PR DESCRIPTION
Delete files from removed packages. Otherwise bitbake will terminate with
the following error:

cairo do_package: QA Issue: cairo: Files/directories were
installed but not shipped in any package:
  /usr/lib/cairo

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>