### PR TITLE
dlt-daemon: remove inherit gzipnative

### DIFF
--- a/meta-ivi/recipes-extended/dlt-daemon/dlt-daemon_2.16.0.bb
+++ b/meta-ivi/recipes-extended/dlt-daemon/dlt-daemon_2.16.0.bb
@@ -21,8 +21,7 @@ SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
     "
 S = "${WORKDIR}/git"
 
-inherit autotools gettext cmake systemd
-inherit gzipnative compress_doc
+inherit autotools gettext cmake systemd compress_doc
 
 PACKAGES += "${PN}-systemd"
 SYSTEMD_PACKAGES = "${PN} ${PN}-systemd"


### PR DESCRIPTION
The class was renamed to gzip-native or pigz-native, which is already a
dependency. Using later verisons of gzip, found in poky 2.3, do not have a
class called gzipnative. By removing it we ensure an error free build.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>