### PR TITLE
node-state-manager: add dependancy to glib-2.0

### DIFF
--- a/meta-ivi/recipes-extended/node-state-manager/node-state-manager_2.0.0.bb
+++ b/meta-ivi/recipes-extended/node-state-manager/node-state-manager_2.0.0.bb
@@ -23,7 +23,7 @@ PR = "r2"
 
 EXTRA_OECONF = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '--with-systemdsystemunitdir=${systemd_unitdir}/system/', '', d)}"
 
-DEPENDS = "dbus glib-2.0 glib-2.0-native dlt-daemon persistence-client-library systemd"
+DEPENDS = "dbus glib-2.0 glib-2.0-native dlt-daemon persistence-client-library systemd glib-2.0 glib-2.0-native"
 
 inherit pkgconfig autotools-brokensep systemd
 


### PR DESCRIPTION
Compilation requires gdbus-codegen, which is in the glib-2.0 package.