### PR TITLE
Update master to 12.0 branch

### DIFF
--- a/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_1.11.1.bb
+++ b/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_1.11.1.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 
 PR = "r0"
 
-SRCREV = "c9001582b10ce209c37b42dd560947c5aa8928b3"
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http \
+SRCREV = "8fdae4cff2647d0060174509990cd2874e1d793d"
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http;branch=1.11 \
     "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The master branch tracks the current stable released Genivi version.
Merge the recent update to 12.0 to update to wayland ivi-extension v1.11.1.