### PR TITLE
gstreamer: add glib-2.0-native to depends

### DIFF
--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.inc
@@ -5,7 +5,7 @@ HOMEPAGE = "http://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
 LICENSE = "LGPLv2+"
-DEPENDS = "glib-2.0 libxml2 bison-native flex-native"
+DEPENDS = "glib-2.0 libxml2 bison-native flex-native glib-2.0-native"
 
 inherit autotools pkgconfig gettext
 


### PR DESCRIPTION
Package requires glib-genmarshal, the lack of which causes the following
build error:

  /bin/bash: line 1: glib-mkenums: command not found
  Makefile:1884: recipe for target 'gstenumtypes.c' failed