### PR TITLE
gstreamer1.0-plugins-base: add glib-2.0-native to depends

### DIFF
--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.inc
@@ -3,7 +3,7 @@ require gstreamer1.0-plugins_1.2.3.inc
 LICENSE = "GPLv2+ & LGPLv2+"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'virtual/libx11 libxv', '', d)}"
-DEPENDS += "freetype liboil util-linux"
+DEPENDS += "freetype liboil util-linux glib-2.0-native"
 
 inherit gettext
 


### PR DESCRIPTION
Package requires glib-genmarshal, the lack of which causes the following
build error:

  /bin/bash: line 1: glib-mkenums: command not found
  Makefile:1270: recipe for target 'video-enumtypes.c' failed