### PR TITLE
gstreamer1.0-plugins-bad: add glib-2.0-native to depends

### DIFF
--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.inc
@@ -2,7 +2,7 @@ require gstreamer1.0-plugins_1.2.3.inc
 
 LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+ "
 
-DEPENDS += "gstreamer1.0-plugins-base bzip2"
+DEPENDS += "gstreamer1.0-plugins-base bzip2 glib-2.0-native"
 
 S = "${WORKDIR}/gst-plugins-bad-${PV}"
 


### PR DESCRIPTION
Package requires glib-genmarshal, the lack of which causes the following
build error:

  /bin/bash: line 1: glib-mkenums: command not found
  Makefile:1128: recipe for target 'photography-enumtypes.h' failed