### PR TITLE
cairo: fix package installation

### DIFF
--- a/meta-ivi/recipes-graphics/cairo/cairo_%.bbappend
+++ b/meta-ivi/recipes-graphics/cairo/cairo_%.bbappend
@@ -11,6 +11,8 @@ do_install_append () {
 	rm -f ${D}${libdir}/cairo/libcairo-trace.so*
 
 	rmdir ${D}${bindir}
+	
+	rm -rf ${D}${libdir}/cairo
 
 	rm -f ${D}${libdir}/libcairo-script-interpreter.so*
 }


### PR DESCRIPTION
The bbappend causes the following issue on do_install:

cairo do_package: QA Issue: cairo: Files/directories were installed but
not shipped in any package:

/usr/lib/cairo