### PR TITLE
dlt-daemon: disable man pages generation

### DIFF
--- a/meta-ivi/recipes-extended/dlt-daemon/dlt-daemon_2.16.0.bb
+++ b/meta-ivi/recipes-extended/dlt-daemon/dlt-daemon_2.16.0.bb
@@ -35,7 +35,7 @@ SYSTEMD_SERVICE_${PN}-systemd = "dlt-example-user.service \
     dlt-receive.service"
 SYSTEMD_AUTO_ENABLE_${PN}-systemd = "disable"
 
-EXTRA_OECMAKE = "-DWITH_SYSTEMD=ON"
+EXTRA_OECMAKE = "-DWITH_SYSTEMD=ON -DWITH_MAN=OFF"
 
 FILES_${PN}-doc += "/usr/share/dlt-filetransfer"
 


### PR DESCRIPTION
Otherwise, it still produces the following error:

| CMake Error at doc/CMakeLists.txt:78 (MESSAGE):
|   Could not find gzip for man page compression.