### PR TITLE
Include gstreamer and cairo appends in 13.0 branch

### DIFF
--- a/meta-ivi/recipes-graphics/cairo/cairo_%.bbappend
+++ b/meta-ivi/recipes-graphics/cairo/cairo_%.bbappend
@@ -11,6 +11,8 @@ do_install_append () {
 	rm -f ${D}${libdir}/cairo/libcairo-trace.so*
 
 	rmdir ${D}${bindir}
+	
+	rm -rf ${D}${libdir}/cairo
 
 	rm -f ${D}${libdir}/libcairo-script-interpreter.so*
 }

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.2.3.inc
@@ -2,7 +2,7 @@ require gstreamer1.0-plugins_1.2.3.inc
 
 LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+ "
 
-DEPENDS += "gstreamer1.0-plugins-base bzip2"
+DEPENDS += "gstreamer1.0-plugins-base bzip2 glib-2.0-native"
 
 S = "${WORKDIR}/gst-plugins-bad-${PV}"
 

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.inc
@@ -3,7 +3,7 @@ require gstreamer1.0-plugins_1.2.3.inc
 LICENSE = "GPLv2+ & LGPLv2+"
 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'virtual/libx11 libxv', '', d)}"
-DEPENDS += "freetype liboil util-linux"
+DEPENDS += "freetype liboil util-linux glib-2.0-native"
 
 inherit gettext
 

--- a/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.inc
+++ b/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0_1.2.3.inc
@@ -5,7 +5,7 @@ HOMEPAGE = "http://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
 LICENSE = "LGPLv2+"
-DEPENDS = "glib-2.0 libxml2 bison-native flex-native"
+DEPENDS = "glib-2.0 libxml2 bison-native flex-native glib-2.0-native"
 
 inherit autotools pkgconfig gettext
 


### PR DESCRIPTION
Trying to do a yocto build synced with pyro branches (for which I guess 13.0 is the closest match) does not work without these changes.

These changes were already in master, this is just a cherry-pick down to 13.0