### PR TITLE
Add "hardening" compiler flags

### DIFF
--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -21,6 +21,15 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 
 PREFERRED_VERSION_wayland-ivi-extension = "2.1"
 
+require conf/distro/include/security_flags.inc
+
+# FIXME: these pkgs are apparently broken when enabling (some of) the
+# security_flags, so they are therefore blacklisted here, (or the flags
+# are _partially) applied)
+SECURITY_CFLAGS_pn-lttng-ust = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-persistence-administrator = ""
+SECURITY_LDFLAGS_pn-persistence-administrator = ""
+
 # do not use gstreamer 1.2.3 by default
 PREFERRED_VERSION_gstreamer1.0              ?= "1.12.2"
 PREFERRED_VERSION_gstreamer1.0-plugins-bad  ?= "1.12.2"


### PR DESCRIPTION
NOTE: Untested - pushing PR for build test.

These gcc flags are quite standard practice but not always applied by
each and every component default settings - hence each Linux distro does
it in their own packaging.

It was requested by Phong Tran in PR #98 for GDP.  These flags are
applied to the whole distro however, which is why they are placed in
meta-ivi distro definition instead.

[GDP-754] Compiler Hardening Flags

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>