### PR TITLE
node-startup-controller: Bump to 1.0.3

### DIFF
--- a/meta-ivi/recipes-extended/node-startup-controller/node-startup-controller_1.0.3.bb
+++ b/meta-ivi/recipes-extended/node-startup-controller/node-startup-controller_1.0.3.bb
@@ -10,29 +10,26 @@ HOMEPAGE = "https://www.genivi.org/"
 SECTION = "base"
 
 LICENSE = "MPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
+LIC_FILES_CHKSUM = "file://COPYING;md5=88220bd246a0e7bb266ce0330a7b2bfa"
 
-PR = "r4"
-
-SRCREV = "717e743c84ef9c168501dcbc012c4212f1903581"
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;nobranch=1;protocol=https \
+SRCREV = "34a421a9267df08d0e72037396b515fe31de5523"
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
            file://use-systemd-unit-dir.patch \
-           file://fix-no-libsystemd-daemon.patch \
           "
 S = "${WORKDIR}/git"
 
 DEPENDS = "glib-2.0 dlt-daemon systemd"
+RDEPENDS_${PN} = "node-state-manager"
 
 inherit autotools gtk-doc systemd
+
 do_configure_prepend () {
         mkdir -p ${S}/m4
 }
 
-PACKAGES =+ "${PN}-nsm-dummy ${PN}-nsm-dummy-dbg"
-
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "node-startup-controller.service"
-SYSTEMD_AUTO_ENABLE = "disable"
+SYSTEMD_AUTO_ENABLE = "enable"
 
 FILES_${PN} += "\
     ${libdir}/${BPN}-1/${BPN} \
@@ -44,15 +41,4 @@ FILES_${PN} += "\
 
 FILES_${PN}-dbg += "\
     ${libdir}/${BPN}-1/.debug/*ler \
-    "
-
-FILES_${PN}-nsm-dummy = "\
-    ${libdir}/${BPN}-1/nsm-dummy \
-    ${datadir}/dbus-1/system-services/org.genivi.NodeStateManager.* \
-    ${sysconfdir}/dbus-1/system.d/org.genivi.NodeStateManager.conf \
-    ${systemd_unitdir}/system/nsm-dummy.service \
-    "
-
-FILES_${PN}-nsm-dummy-dbg = "\
-    ${libdir}/${BPN}-1/.debug/nsm-dummy \
     "


### PR DESCRIPTION
- Bump version
- Enable by default
- Add node-state-manager as a requirement