### PR TITLE
audio manager: update to v7.6

### DIFF
--- a/meta-ivi/recipes-multimedia/audiomanager/audiomanager_7.6.bb
+++ b/meta-ivi/recipes-multimedia/audiomanager/audiomanager_7.6.bb
@@ -10,7 +10,7 @@ DEPENDS = "common-api-c++-dbus dlt-daemon sqlite3 dbus node-state-manager"
 
 inherit gettext cmake pkgconfig systemd
 _BPN = "AudioManager"
-SRCREV = "8f2387e42641c7c2b967553a4c578f0e87549fb6"
+SRCREV = "bcaeed20bbbb4375ae925d507821d2bef64e737b"
 SRC_URI = " git://github.com/GENIVI/${_BPN}.git;protocol=https \
     file://${_BPN}.service \
     file://setup_amgr.sh \

--- a/meta-ivi/recipes-multimedia/audiomanager/audiomanagerplugins_7.6.bb
+++ b/meta-ivi/recipes-multimedia/audiomanager/audiomanagerplugins_7.6.bb
@@ -10,7 +10,7 @@ DEPENDS = "audiomanager capicxx-core-native capicxx-dbus-native \
     python3 libxml2"
 RDEPENDS_${PN} += "libxml2"
 
-SRCREV = "6e167422e68089fee3098163b63f882ce4a50ad3"
+SRCREV = "03fa3696fbbc1d624095bfc60f80b9ec071bec07"
 SRC_URI = " git://github.com/GENIVI/AudioManagerPlugins.git;protocol=https \
     file://AM-Genivi-Filtering-out-JDK-warnings-in-CAPI-script.patch \
     "


### PR DESCRIPTION
Update meta-ivi to version 7.6 of the Genivi Audio Manager and Audio Manager Plugins components.

@frznlogic: I have merged the latest (unrelated to this) master changes since I first did this work and am currently rebuilding. Will update the comments with the result tomorrow. I think this will be applicable to the Genivi 13 branch as well as v7.6 has many fixes and has no API breakage.