### PR TITLE
bluez5: Fix compilation for test

### DIFF
--- a/meta-ivi-test/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/meta-ivi-test/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,7 +1,7 @@
 #
 # for test
 #
-PACKAGECONFIG += " experimental"
+PACKAGECONFIG += " readline testing tools"
 
 do_install_append() {
    install -d ${D}/opt/tests/${PN}


### PR DESCRIPTION
The PACKAGECONFIG to compile the bluez5-noinst-tools has changed with the
latest bump of poky. This commit fixes the configuration.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>