### PR TITLE
qemu_2: Remove dependency on libusb

### DIFF
--- a/meta-ivi/recipes-devtools/qemu/qemu_2.%.bbappend
+++ b/meta-ivi/recipes-devtools/qemu/qemu_2.%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG_append = " virtfs libusb"
+PACKAGECONFIG_append = " virtfs"
 
 EXTRA_OECONF += " --audio-drv-list=pa"
 EXTRA_OECONF_remove_pn-nativesdk-qemu = "--audio-drv-list=pa"


### PR DESCRIPTION
This is a really old dependency append it's causing issues in builds
relying on the meta-ivi layer. Removing it as it doesn't seem necessary.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>