### PR TITLE
distro: poky-ivi-systemd: inherit from poky

### DIFF
--- a/README.build
+++ b/README.build
@@ -52,16 +52,3 @@ to use am 7.0, put following lines to <build directory>/conf/local.conf
 # use audiomanager 7.0 until am7.4 issues are fixed.
 PREFERRED_VERSION_audiomanager          ?= "7.0"
 PREFERRED_VERSION_audiomanagerplugins   ?= "7.0"
-
-
-Build s/w packages using gstreamer1.0-\*\_1.2.3.bb instead of default version
------------------------------------------------------------------------------
-you may encounter a build error like below:
-
-ERROR: Nothing PROVIDES 'tremor' (but /opt/genivi-baseline_13/poky/../meta-ivi/meta-ivi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.2.3.bb DEPENDS on or otherwise requires it)
-ERROR: Required build target 'gstreamer1.0-plugins-base' has no buildable providers.
-Missing or unbuildable dependency chain was: ['gstreamer1.0-plugins-base', 'tremor']
-
-then you may need "tremor" package for build this package.
-add following line to your conf/bblayser.conf.
-BBLAYERS_append := " <your topdir>/meta-openembedded/meta-multimedia"

--- a/meta-ivi/conf/distro/include/default-providers-ivi.inc
+++ b/meta-ivi/conf/distro/include/default-providers-ivi.inc
@@ -3,4 +3,3 @@
 #
 PREFERRED_PROVIDER_udev ?= "systemd"
 PREFERRED_PROVIDER_udev-utils ?= "systemd"
-PREFERRED_PROVIDER_node-state-manager ?= "node-state-manager"

--- a/meta-ivi/conf/distro/include/default-providers-ivi.inc
+++ b/meta-ivi/conf/distro/include/default-providers-ivi.inc
@@ -1,5 +1,0 @@
-#
-# Default virtual providers
-#
-PREFERRED_PROVIDER_udev ?= "systemd"
-PREFERRED_PROVIDER_udev-utils ?= "systemd"

--- a/meta-ivi/conf/distro/include/default-providers-ivi.inc
+++ b/meta-ivi/conf/distro/include/default-providers-ivi.inc
@@ -4,9 +4,3 @@
 PREFERRED_PROVIDER_udev ?= "systemd"
 PREFERRED_PROVIDER_udev-utils ?= "systemd"
 PREFERRED_PROVIDER_node-state-manager ?= "node-state-manager"
-
-#
-# Default jpeg provider
-#
-PREFERRED_PROVIDER_jpeg ?= "jpeg"
-PREFERRED_PROVIDER_jpeg-native ?= "jpeg-native"

--- a/meta-ivi/conf/distro/include/default-providers-ivi.inc
+++ b/meta-ivi/conf/distro/include/default-providers-ivi.inc
@@ -1,7 +1,6 @@
 #
 # Default virtual providers
 #
-PREFERRED_PROVIDER_virtual/arm-oe-linux-gnueabi-depmod ?= "kmod-cross"
 PREFERRED_PROVIDER_udev ?= "systemd"
 PREFERRED_PROVIDER_udev-utils ?= "systemd"
 PREFERRED_PROVIDER_node-state-manager ?= "node-state-manager"

--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -3,7 +3,7 @@ require conf/distro/poky.conf
 DISTRO = "poky-ivi-systemd"
 DISTRO_NAME = "Yocto GENIVI Baseline (Poky/meta-ivi)"
 DISTRO_VERSION = "14.0.0"
-DISTRO_CODENAME ="pulsar"
+DISTRO_CODENAME = "pulsar"
 
 MAINTAINER = "meta-ivi <genivi-meta-ivi@lists.genivi.org>"
 

--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -42,14 +42,6 @@ SECURITY_LDFLAGS_pn-v86d = ""
 SECURITY_CFLAGS_pn-gettext = ""
 SECURITY_LDFLAGS_pn-gettext = ""
 
-# do not use gstreamer 1.2.3 by default
-PREFERRED_VERSION_gstreamer1.0              ?= "1.12.2"
-PREFERRED_VERSION_gstreamer1.0-plugins-bad  ?= "1.12.2"
-PREFERRED_VERSION_gstreamer1.0-plugins-base ?= "1.12.2"
-PREFERRED_VERSION_gstreamer1.0-plugins-good ?= "1.12.2"
-PREFERRED_VERSION_gstreamer1.0-plugins-ugly ?= "1.12.2"
-PREFERRED_VERSION_gstreamer1.0-libav        ?= "1.12.2"
-PREFERRED_VERSION_gstreamer1.0-omx          ?= "1.12.2"
 QEMU_TARGETS ?= "arm aarch64 i386 x86_64"
 
 XSERVER ?= "xserver-xorg \

--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -1,3 +1,5 @@
+require conf/distro/poky.conf
+
 DISTRO = "poky-ivi-systemd"
 DISTRO_NAME = "Yocto GENIVI Baseline (Poky/meta-ivi)"
 DISTRO_VERSION = "14.0.0"
@@ -5,18 +7,23 @@ DISTRO_CODENAME ="pulsar"
 
 MAINTAINER = "meta-ivi <genivi-meta-ivi@lists.genivi.org>"
 
-TARGET_VENDOR = "-poky"
-
-LOCALCONF_VERSION = "1"
-LAYER_CONF_VERSION ?= "6"
+POKY_DEFAULT_DISTRO_FEATURES = "\
+    bluetooth \
+    largefile \
+    opengl \
+    pam \
+    systemd \
+    wayland \
+"
 
 include conf/distro/include/default-providers-ivi.inc
+# Conflicts with wayland. It is possible run wayland
+# on-top of x11 but that is not a use-case that we support
+DISTRO_FEATURES_remove = "x11 directfb"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = ""
 
-DISTRO_FEATURES_append = " bluetooth systemd opengl wayland pam bluez5"
-DISTRO_FEATURES_remove = "x11"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 
 require conf/distro/include/security_flags.inc
@@ -43,15 +50,6 @@ PREFERRED_VERSION_gstreamer1.0-plugins-good ?= "1.12.2"
 PREFERRED_VERSION_gstreamer1.0-plugins-ugly ?= "1.12.2"
 PREFERRED_VERSION_gstreamer1.0-libav        ?= "1.12.2"
 PREFERRED_VERSION_gstreamer1.0-omx          ?= "1.12.2"
-
-POKYQEMUDEPS = "${@bb.utils.contains("INCOMPATIBLE_LICENSE", "GPLv3", "", "packagegroup-core-device-devel",d)}"
-DISTRO_EXTRA_RDEPENDS_append_qemuarm = " ${POKYQEMUDEPS}"
-DISTRO_EXTRA_RDEPENDS_append_qemux86 = " ${POKYQEMUDEPS}"
-DISTRO_EXTRA_RDEPENDS_append_qemux86-64 = " ${POKYQEMUDEPS}"
-DISTRO_EXTRA_RDEPENDS_append_vexpressa9 = " ${POKYQEMUDEPS}"
-
-TCLIBCAPPEND = ""
-
 QEMU_TARGETS ?= "arm aarch64 i386 x86_64"
 
 XSERVER ?= "xserver-xorg \
@@ -69,62 +67,3 @@ XSERVER ?= "xserver-xorg \
            ${@bb.utils.contains("MACHINE_ARCH", "qemux86_64", "xf86-video-vmware", "", d)} \
            ${@bb.utils.contains("MACHINE_ARCH", "vexpressa9", "xf86-video-fbdev", "", d)} \
           "
-
-PREMIRRORS ??= "\
-bzr://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-cvs://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-git://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-gitsm://.*/.* http://downloads.yoctoproject.org/mirror/sources/ \n \
-hg://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
-osc://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-p4://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
-svn://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n"
-
-MIRRORS =+ "\
-ftp://.*/.*      http://downloads.yoctoproject.org/mirror/sources/ \n \
-http://.*/.*     http://downloads.yoctoproject.org/mirror/sources/ \n \
-https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n"
-
-# The CONNECTIVITY_CHECK_URI's are used to test whether we can succesfully
-# fetch from the network (and warn you if not). To disable the test set
-# the variable to be empty.
-# Git example url: git://git.yoctoproject.org/yocto-firewall-test;protocol=git;rev=HEAD
-
-CONNECTIVITY_CHECK_URIS ?= " \
-             https://eula-downloads.yoctoproject.org/index.php \
-             http://www.genivi.org"
-
-# Default hash policy for distro
-BB_SIGNATURE_HANDLER ?= 'OEBasicHash'
-#
-# OELAYOUT_ABI allows us to notify users when the format of TMPDIR changes in
-# an incompatible way. Such changes should usually be detailed in the commit
-# that breaks the format and have been previously discussed on the mailing list
-# with general agreement from the core team.
-#
-OELAYOUT_ABI = "11"
-
-# add poky sanity bbclass
-INHERIT += "poky-sanity"
-
-# QA check settings - a little stricter than the OE-Core defaults
-WARN_QA = "textrel files-invalid incompatible-license xorg-driver-abi libdir \
-           unknown-configure-option build-deps"
-ERROR_QA = "dev-so debug-deps dev-deps debug-files arch pkgconfig la perms \
-            useless-rpaths rpaths staticdev ldflags pkgvarcheck already-stripped \
-            compile-host-path dep-cmp installed-vs-shipped install-host-path \
-            packages-list perm-config perm-line perm-link pkgv-undefined \
-            pn-overrides split-strip var-undefined version-going-backwards"
-
-# Recent changes in siggen.py check for task hash and generate build errors
-# called Taskhash mismatch when using variables with date and time. Exclude
-# date variables as done.
-# see https://lists.yoctoproject.org/pipermail/poky/2016-April/010470.html
-DISTRO_VERSION[vardepsexclude] = "DATE"
-SDK_VERSION[vardepsexclude] = "DATE"
-
-#
-# TO DO
-# When bug is fixed: https://bugzilla.yoctoproject.org/show_bug.cgi?id=5968
-# In quilt binary diffs are not supported. Use git as tool for applying patches.
-# PATCHTOOL = 'git'

--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -21,6 +21,8 @@ include conf/distro/include/default-providers-ivi.inc
 # on-top of x11 but that is not a use-case that we support
 DISTRO_FEATURES_remove = "x11 directfb"
 
+PREFERRED_PROVIDER_udev ?= "systemd"
+PREFERRED_PROVIDER_udev-utils ?= "systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = ""
 

--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -43,19 +43,3 @@ SECURITY_CFLAGS_pn-gettext = ""
 SECURITY_LDFLAGS_pn-gettext = ""
 
 QEMU_TARGETS ?= "arm aarch64 i386 x86_64"
-
-XSERVER ?= "xserver-xorg \
-           xserver-xf86-config \
-           xserver-xorg-extension-dbe \
-           xserver-xorg-extension-dri \
-           xserver-xorg-extension-dri2 \
-           xserver-xorg-extension-extmod \
-           xserver-xorg-extension-glx \
-           xf86-input-evdev \
-           xf86-input-mouse \
-           xf86-input-keyboard \
-           mesa-driver-swrast \
-           ${@bb.utils.contains("MACHINE_ARCH", "qemux86", "xf86-video-vmware", "", d)} \
-           ${@bb.utils.contains("MACHINE_ARCH", "qemux86_64", "xf86-video-vmware", "", d)} \
-           ${@bb.utils.contains("MACHINE_ARCH", "vexpressa9", "xf86-video-fbdev", "", d)} \
-          "


### PR DESCRIPTION
Build tested with

    export MACHINE=qemux86-64 ; bitbake pulsar-image

and boot tested with

    runqemu nographics

No obvious problems. This might expose some QA warnings and errors due to it being a bit different to what was present and what is in "rocko" poky.conf.