### PR TITLE
README.md: update meta-gplv2 commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ URI: git://git.openembedded.org/meta-openembedded
 
 URI: git://git.yoctoproject.org/meta-gplv2
 > branch:   rocko
-> revision: b3092960655f51febbcb2dba78ca6fdd7091098f
+> revision: f875c60ecd6f30793b80a431a2423c4b98e51548
 
 Using the above git SHAs and the master meta-ivi branch,
  bitbaking pulsar-image is known to work


### PR DESCRIPTION
Update to the current meta-gplv2 rocko branch head commit.

This fixes a coreutils build warning with meta-ivi. See commit message
for c47d8ec for details.

Change should be applied to 14.x branch as well.

Tested on Renesas R-Car M3 Starter Kit in the following build configuration:
BB_VERSION           = "1.36.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-16.04"
TARGET_SYS           = "aarch64-poky-linux"
MACHINE              = "m3ulcb"
DISTRO               = "poky-ivi-systemd"
DISTRO_VERSION       = "14.0.0"
TUNE_FEATURES        = "aarch64 cortexa57-cortexa53"
TARGET_FPU           = ""
SOC_FAMILY           = "rcar-gen3:r8a7796"
meta                 
meta-poky            
meta-yocto-bsp       = "HEAD:6b744113ad3e564d1cb05411816b103d99fd84dc"
meta-oe              
meta-filesystems     = "rocko:dacfa2b1920e285531bec55cd2f08743390aaf57"
meta-ivi             
meta-ivi-bsp         = "14.x:2c11b36653a3c5c0657dedfdfcf78278a9920f22"
meta-gplv2           = "rocko:f875c60ecd6f30793b80a431a2423c4b98e51548"
meta-rcar-gen3       = "rocko:d50e055494cea5de0a348c15ee27cb67a3542e0b"
meta-optee           = "rocko:75dfb67bbb14a70cd47afda9726e2e1c76731885"
meta-ivi-renesas     = "genivi-14.x:e1e5223d7f3d36b65f45f7d4408271b622506082"

Short log:
f875c60 diffutils Make it build with compile time hardening enabled
125e5ff rsync: Make it build with compile time hardening enabled
de94e04 patch: Make it build with compile time hardening enabled
1bf9ef7 rxvt-unicode: Inherit pkgconfig
acfb500 rxvt-unicode: Make it build with C++11
3e40e7d README: Add Peter Kjellerstedt as co-maintainer
392b499 texinfo: Update a patch to avoid fuzz
fc99e81 gnupg: Update a patch to avoid fuzz
5fe7a92 dosfstools: Update a patch to avoid fuzz
3ed1fb3 sed: Update a patch to avoid fuzz
c47d8ec coreutils: Update a patch to avoid fuzz
c0a5943 coreutils: Avoid warnings due to update-alternatives for man pages
9809f69 bash: Provide /bin/{sh, bash} when usrmerge is used