### PR TITLE
Update MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -42,7 +42,7 @@ Please keep this list in alphabetical order.
 Maintainers List (try to look for most precise areas first)
 
 COMMON
-M:	Yong-iL Joh <yong-il.joh@windriver.com>
+M:  Oscar Andreasson <oandreasson@luxoft.com>
 F:	./meta-ivi/
 F:	./meta-ivi-bsp/
 F:	./meta-ivi-test/


### PR DESCRIPTION
Tolkien no longer maintains the meta-ivi layer, it has been moved to my
table. I've missed updating this file earlier.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>