### PR TITLE
ivi-image: remove hard-coded IMAGE_ROOTFS_SIZE

### DIFF
--- a/meta-ivi/recipes-yocto-ivi/images/ivi-image.inc
+++ b/meta-ivi/recipes-yocto-ivi/images/ivi-image.inc
@@ -9,8 +9,6 @@ LICENSE = "MIT"
 
 inherit core-image buildhistory
 
-IMAGE_ROOTFS_SIZE = "8192"
-
 IMAGE_FEATURES += " package-management"
 
 # Create SD image symlink correctly


### PR DESCRIPTION
The image rootfs size is determined by the following algorithm
(from Yocto ref manual):

    if (image-du * overhead) < rootfs-size:
        internal-rootfs-size = rootfs-size + xspace
    else:
        internal-rootfs-size = (image-du * overhead) + xspace

Currently rootfs-size is set to 8 MB which essentially means that it
will never be used as it is considered as a minimum. By removing it
from the image, the weak default value (65536) will be used which is
defined in bitbake.conf.

The primary reason of removing it is to be able to set a custom value in
e.g local.conf which is currently not possible.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>