### PR TITLE
Persistence and lifecycle updates 

### DIFF
--- a/meta-ivi/recipes-extended/node-health-monitor/node-health-monitor_1.3.7.bb
+++ b/meta-ivi/recipes-extended/node-health-monitor/node-health-monitor_1.3.7.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 PR = "r3"
 
-SRCREV="6aa24c04080c3cd0389934841fae5ac502b8e13a"
+SRCREV = "80ae9bb60a40d1fc3a43f81119030e35395c7a8c"
 SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
     file://fix-no-libsystemd-daemon.patch \
     file://0001-change-service-name.patch \

--- a/meta-ivi/recipes-extended/persistence-administrator/persistence-administrator_1.0.10.bb
+++ b/meta-ivi/recipes-extended/persistence-administrator/persistence-administrator_1.0.10.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 PR = "r0"
 
-SRCREV = "635b4843b5189d68c38abfa14c9cd61815b2152b"
+SRCREV = "ebfb5ddea6976d1a30da78b17bf9821f2b0fda80"
 SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https "
 S = "${WORKDIR}/git"
 

--- a/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.2.0.bb
+++ b/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.2.0.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6161c6840f21a000e9b52af81d2ca823"
 
 DEPENDS = "dlt-daemon dbus libcheck persistence-common-object"
 
-SRCREV = "140cb9c7dbea24d887a556ac9b90a548f59bd47e"
+SRCREV = "797e31444eff1ec4d9977ed040696b2baff09752"
 SRC_URI = " \
     git://github.com/GENIVI/${BPN}.git;protocol=https \
     file://0001-fix-exec-path.patch \

--- a/meta-ivi/recipes-extended/persistence-common-object/persistence-common-object_1.1.0.bb
+++ b/meta-ivi/recipes-extended/persistence-common-object/persistence-common-object_1.1.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 PR = "r2"
 
-SRCREV = "7d397aedf857d3af39372fdf6fdc6a292ede87ac"
+SRCREV = "6e827a990f7e0dceeaeddb7f16c710b7cc30f2fe"
 SRC_URI = " git://github.com/GENIVI/${BPN}.git;protocol=https \
     "
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Note that the name of the PAS update is just slightly speculative since the 1.0.10 tag does not yet exist.  
Therefore WIP.  

But the SRCREV exists on the master branch so this recipe update will need to be done anyway.  But I see little reason that it will not be tagged exactly this way...

The other components have already received new version/tags by me.
