### PR TITLE
bluez5: enable obex-profiles

### DIFF
--- a/meta-ivi/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/meta-ivi/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 
+PACKAGECONFIG_append = " obex-profiles"
+
 #
 # Service API reference implementation
 # Revision: 5.15 (Horizon)


### PR DESCRIPTION
Without this --disable-obex is passed to configure and no bluez5-obex*.rpm
is generated. packagegroup-abstract-component-p1.bb in
meta-ivi/recipes-yocto-ivi/packagegroups/ RDEPENDS on bluez5-obex.

Error without this patch when enabling meta-ivi-test and bitbake:ing
test-image:

Error:
 Problem: conflicting requests
  - nothing provides bluez5-obex needed by packagegroup-abstract-component-p1-1.0-r0.noarch