### PR TITLE
ci-build: tell CI what gfx/mmp pkgs to use for Renesas R-Car Gen 3 builds on Thud

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -9,7 +9,7 @@
 AGENT_STANDARD_DL_DIR="/var/cache/yocto/downloads"
 AGENT_STANDARD_SSTATE_DIR="/var/cache/yocto/sstate"
 AGENT_STANDARD_SGX_LOCATION="/var/go/sgx_bin"
-AGENT_STANDARD_SGX_GEN3_LOCATION="/var/go/rcar-gen3/gfx-mmp_ybsp-390_20180627"
+AGENT_STANDARD_SGX_GEN3_LOCATION="/var/go/rcar-gen3/gfx-mmp_ybsp-315_20190212"
 
 
 # ---- Helper functions ----


### PR DESCRIPTION
This should only be merged once @gunnarx has updated the CI to add the gfx/mmp packages to the CI build nodes. JIRA ticket for that task is [BASE-65](https://at.projects.genivi.org/jira/browse/BASE-65)
-
Specify which directory the CI should get the correct "click through"
licensed gfx/mmp packages from when building the Renesas R-Car Gen 3
Yocto BSP v3.15.0 for Yocto Project 2.6 (Thud).

Signed-off-by: Stephen Lawrence <stephen.lawrence@renesas.com>