### PR TITLE
MAINTAINERS: remove maintainer's email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -20,8 +20,7 @@ When creating patches, please use something like:
     git format-patch -s --subject-prefix='meta-ivi][PATCH' origin
 
 When sending patches, please use something like:
-    git send-email --to=oandreasson@luxoft.com \
-                   --cc=genivi-meta-ivi@lists.genivi.org <generated patch>
+    git send-email --to=genivi-meta-ivi@lists.genivi.org <generated patch>
 
 Please refer to:
 https://at.projects.genivi.org/wiki/display/PROJ/How+to+contribute+to+GENIVI


### PR DESCRIPTION
Maintainers tend to change, but their names and emails tend to stay in the
contributing instructions for much longer.

Also, this makes no sense to CC a person who is actively using the designated mailing list, so remove maintainer's email address and
leave mailing list only.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>