### PR TITLE
Rename image from pulsar-image to meta-ivi-image

### DIFF
--- a/README.build
+++ b/README.build
@@ -11,7 +11,7 @@ export TEMPLATECONF=PATH_TO_META_IVI/meta-ivi/meta-ivi/conf
    > $ source poky/oe-init-build-env
 
 3. Build a s/w image including GENIVI 13.0 (Orion) components
-   > $ bitbake pulsar-image
+   > $ bitbake meta-ivi-image
 
 4. Run the emulator:
    > for qemu vexpressa9:  

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ URI: git://git.yoctoproject.org/meta-gplv2
 > revision: aabc30f3bd03f97326fb8596910b94639fea7575
 
 Using the above git SHAs and the master meta-ivi branch,
- bitbaking pulsar-image is known to work
- (the pulsar-image build should be aligned with GENIVI 14.0).
+ bitbaking meta-ivi-image is known to work.
 
 For creating a specific GENIVI compliant image version, please make sure you
 git checkout the related meta-ivi branch and follow the build instructions

--- a/meta-ivi/conf/conf-notes.txt
+++ b/meta-ivi/conf/conf-notes.txt
@@ -1,4 +1,4 @@
 Common targets are:
-    pulsar-image
+    meta-ivi-image
     ivi-image
 

--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -2,8 +2,8 @@ require conf/distro/poky.conf
 
 DISTRO = "poky-ivi-systemd"
 DISTRO_NAME = "Yocto GENIVI Baseline (Poky/meta-ivi)"
-DISTRO_VERSION = "14.0.0"
-DISTRO_CODENAME = "pulsar"
+DISTRO_VERSION = "15.0.0"
+DISTRO_CODENAME = "meta-ivi"
 
 MAINTAINER = "meta-ivi <genivi-meta-ivi@lists.genivi.org>"
 

--- a/meta-ivi/recipes-yocto-ivi/images/meta-ivi-image.bb
+++ b/meta-ivi/recipes-yocto-ivi/images/meta-ivi-image.bb
@@ -1,5 +1,5 @@
 # Base this image on generic IVI image
 require recipes-yocto-ivi/images/ivi-image.bb
 
-PV = "14.0.0"
+PV = "15.0.0"
 

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -595,7 +595,7 @@ fi
 # of the SDK parts.
 
 if [[ "$BUILD_SDK" != "true" ]]; then
-  bitbake pulsar-image
+  bitbake meta-ivi-image
 fi
 
 if [[ "$BUILD_TEST_IMAGE" == "true" ]]; then
@@ -605,7 +605,7 @@ fi
 
 if [[ "$BUILD_SDK" == "true" ]]; then
   # (Anticipating a future sdk image:)
-  bitbake pulsar-image-sdk
+  bitbake meta-ivi-image-sdk
 fi
 
 cd "$BASEDIR"


### PR DESCRIPTION
There is no suitable code name for the 15.0.0 release. Use a more generic image name.