### PR TITLE
persistence-administrator: snprintf compliance

### DIFF
--- a/meta-ivi/recipes-extended/persistence-administrator/persistence-administrator_1.0.10.bb
+++ b/meta-ivi/recipes-extended/persistence-administrator/persistence-administrator_1.0.10.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 PR = "r0"
 
-SRCREV = "ebfb5ddea6976d1a30da78b17bf9821f2b0fda80"
+SRCREV = "bfe6519c91ffda39004b485d3d6abc852efe913e"
 SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
 Make snprintf comply with -Werror=format-security

Fixes the following error when bulding with GCC 8.2 and
-Werror=format-security:

  error: format not a string literal and no format arguments
  [-Werror=format-security]

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>