### PR TITLE
persistent-client-library: add persistence-administrator to RDEPENDS

### DIFF
--- a/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.2.0.bb
+++ b/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.2.0.bb
@@ -38,4 +38,7 @@ FILES_${PN}-dev += " \
     ${libdir}/libpersistence_client_library.so \
     "
 
-RDEPENDS_${PN} = "node-state-manager"
+RDEPENDS_${PN} = " \
+    node-state-manager \
+    persistence-administrator \
+"


### PR DESCRIPTION
The persistence-client-library README contains the persistence-administrator daemon running as a precondition:

"Persistence Administration Service is available in the system and running"