### PR TITLE
Update PCO and PCL to new version (changed D-Bus installation policy)

### DIFF
--- a/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.2.1.bb
+++ b/meta-ivi/recipes-extended/persistence-client-library/persistence-client-library_1.2.1.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6161c6840f21a000e9b52af81d2ca823"
 
 DEPENDS = "dlt-daemon dbus libcheck persistence-common-object"
 
-SRCREV = "797e31444eff1ec4d9977ed040696b2baff09752"
+SRCREV = "0cb972e8024a7d31aa0b637afbf45bdd1f6f8359"
 SRC_URI = " \
     git://github.com/GENIVI/${BPN}.git;protocol=https \
     file://0001-fix-exec-path.patch \

--- a/meta-ivi/recipes-extended/persistence-common-object/persistence-common-object_1.1.1.bb
+++ b/meta-ivi/recipes-extended/persistence-common-object/persistence-common-object_1.1.1.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 PR = "r2"
 
-SRCREV = "6e827a990f7e0dceeaeddb7f16c710b7cc30f2fe"
+SRCREV = "ef393dc635875bb0bbb25abf66cfe42cfa5d6842"
 SRC_URI = " git://github.com/GENIVI/${BPN}.git;protocol=https \
     "
 S = "${WORKDIR}/git"
@@ -19,9 +19,5 @@ DEPENDS = "glib-2.0 glib-2.0-native dlt-daemon libcheck libarchive"
 inherit autotools-brokensep pkgconfig
 
 EXTRA_OECONF = " --with-database=key-value-store "
-
-do_install_append() {
-    rm -rf ${D}${sysconfdir}
-}
 
 FILES_${PN} := "${prefix}"


### PR DESCRIPTION
Updated versions (note, new patch level tag was created on each of the components)

Changes according to details given by Martin here:
https://github.com/GENIVI/persistence-common-object/pull/8

It is intentional to remove the do_install_append() here.  I should probably have mentioned in the commit comment that:  It is no longer needed to remove sysconfdir to avoid conflict.  

