### PR TITLE
audiomanager: Remove custom do_qa_staging

### DIFF
--- a/meta-ivi/recipes-multimedia/audiomanager/audiomanager_7.6.bb
+++ b/meta-ivi/recipes-multimedia/audiomanager/audiomanager_7.6.bb
@@ -45,11 +45,3 @@ do_install_append() {
     perl -pi -e 's|set_and_check\(|#set_and_check\(|' ${D}${libdir}/cmake/*/*.cmake
 
 }
-
-# replace function in poky/meta/classes/insane.bbclass
-python do_qa_staging() {
-    bb.note("[workaround] QA checking staging")
-
-    if not qa_check_staged(d.expand('${SYSROOT_DESTDIR}${STAGING_LIBDIR}'), d):
-        bb.fatal("QA staging was broken by the package built above")
-}


### PR DESCRIPTION
The build script had a custom definition of do_qa_staging
which now seems to be failing with this error:

   Exception: NameError: name 'qa_check_staged' is not defined

Something probably changed in OE/Poky that makes this code no longer
applicable.  If QA is not generally failing on a normal build then I
don't see a strong reason to keep this special code so the easiest
approach seems to remove it from the recipe.
