### PR TITLE
common-api: Upgrade to latest versions available

### DIFF
--- a/meta-ivi/recipes-extended/common-api/capicxx-core-native_3.1.12.4.bb
+++ b/meta-ivi/recipes-extended/common-api/capicxx-core-native_3.1.12.4.bb
@@ -6,4 +6,5 @@ LAUNCHER_LINK = "capicxx-core-gen"
 require capicxx-native.inc
 
 SRC_URI = "https://github.com/GENIVI/${_BPN}-tools/releases/download/${PV}/commonapi-generator.zip"
-SRC_URI[sha256sum] = "979abe3c2ff29e6c5e8a61cdfbd262bf837e6a26201593c5e6e38160978f2a21"
+SRC_URI[sha256sum] = "6de1720a80c6b61c1f20512e03f86c29b21f4df572c89e1f9b2e38923177b3ea"
+

--- a/meta-ivi/recipes-extended/common-api/capicxx-dbus-native_3.1.12.2.bb
+++ b/meta-ivi/recipes-extended/common-api/capicxx-dbus-native_3.1.12.2.bb
@@ -6,4 +6,4 @@ LAUNCHER_LINK = "capicxx-dbus-gen"
 require capicxx-native.inc
 
 SRC_URI = "https://github.com/GENIVI/${_BPN}-tools/releases/download/${PV}/commonapi_dbus_generator.zip"
-SRC_URI[sha256sum] = "6fb53b10ae49952383c8eb990995c6a3197055ccb51b199c8570b89b73522669"
+SRC_URI[sha256sum] = "ee7c4bcffc38b9526ae179a057d39d3a2170622efddc924fc91cc42835d082f5"

--- a/meta-ivi/recipes-extended/common-api/capicxx-native.inc
+++ b/meta-ivi/recipes-extended/common-api/capicxx-native.inc
@@ -19,7 +19,6 @@ def get_launcher_name(d):
 LAUNCHER = "${@get_launcher_name(d)}"
 
 inherit native
-SANITY_REQUIRED_UTILITIES += "java"
 
 S = "${WORKDIR}"
 DD = "${D}${datadir}/${PN}-${PV}"

--- a/meta-ivi/recipes-extended/common-api/capicxx-someip-native_3.1.12.2.bb
+++ b/meta-ivi/recipes-extended/common-api/capicxx-someip-native_3.1.12.2.bb
@@ -6,4 +6,4 @@ LAUNCHER_LINK = "capicxx-someip-gen"
 require capicxx-native.inc
 
 SRC_URI = "https://github.com/GENIVI/${_BPN}-tools/releases/download/${PV}/commonapi_someip_generator.zip"
-SRC_URI[sha256sum] = "2983ed31d4f99e1b018ef8cc12fe68d08bf8379b845fee2c324f655731c42f9a"
+SRC_URI[sha256sum] = "493bc17292e94767277a3b0763c81ead6e3fe1a3778e7c934c64c3197146b60f"

--- a/meta-ivi/recipes-extended/common-api/common-api-c++-dbus_3.1.12.11.bb
+++ b/meta-ivi/recipes-extended/common-api/common-api-c++-dbus_3.1.12.11.bb
@@ -8,7 +8,7 @@ PR = "r0"
 DEPENDS = "commonapi3 dbus"
 REQUIRES = "commonapi3 dbus"
 
-SRCREV = "77fd3ae09034b6f7cb87be7fd77d08cf106f53cb"
+SRCREV = "9f85f0f18d9ca436fb618769149ee02e78fd283b"
 SRC_URI = "git://github.com/GENIVI/capicxx-dbus-runtime.git;protocol=https"
 S = "${WORKDIR}/git"
 

--- a/meta-ivi/recipes-extended/common-api/common-api-c++-someip_3.1.12.17.bb
+++ b/meta-ivi/recipes-extended/common-api/common-api-c++-someip_3.1.12.17.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
 
 DEPENDS = "boost common-api-c++ vsomeip"
 
-SRCREV = "64f0cb0133b23ff13c48c377546cdaef45b3d9ce"
+SRCREV = "c262d86dde371d8118285ee4783beeed83bf8c27"
 SRC_URI = "git://github.com/GENIVI/capicxx-someip-runtime.git;protocol=https \
     "
 S = "${WORKDIR}/git"

--- a/meta-ivi/recipes-extended/common-api/common-api-c++_3.1.12.6.bb
+++ b/meta-ivi/recipes-extended/common-api/common-api-c++_3.1.12.6.bb
@@ -10,7 +10,7 @@ DEPENDS = "dlt-daemon"
 
 inherit cmake lib_package pkgconfig
 
-SRCREV = "2fd0625d21f1fa8e6a3adfc89ce9f381a4d33990"
+SRCREV = "99ebf3461f51e4899f06457d6aafdaa4adecd278"
 SRC_URI = "git://github.com/GENIVI/capicxx-core-runtime.git;protocol=https \
     "
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The common-api recipes (native and target ones) are update to the latest
upstream version available. SRC_URI checks are update to mach these new
versions.

The flag SANITY_REQUIRED_UTILITIES on java is moved inside the right
location. This flag is only working inside a distro.conf or local.conf
file. Now, you will really have an error if you try to launch a build of
the ivi image without java on your machine.

Signed-off-by: Sebastien RAILLET <sebastien.raillet@marelli.com>