### PR TITLE
Adds SANITY_REQUIRED_UTILITIES for java

### DIFF
--- a/meta-ivi/conf/distro/poky-ivi-systemd.conf
+++ b/meta-ivi/conf/distro/poky-ivi-systemd.conf
@@ -28,6 +28,8 @@ VIRTUAL-RUNTIME_initscripts = ""
 
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 
+SANITY_REQUIRED_UTILITIES += "java"
+
 # FIXME: these pkgs are apparently broken when enabling (some of) the
 # security_flags, so they are therefore blacklisted here, (or the flags
 # are _partially) applied)


### PR DESCRIPTION
The flag SANITY_REQUIRED_UTILITIES on java is effective only
inside a distro.conf or local.conf file. Knowing that common-api
generators need java to work properly, you will now have an error
if you try to launch a build of the ivi image without java on your machine