### PR TITLE
meta-ivi: assert hardknott LAYERSERIES_COMPAT

### DIFF
--- a/meta-ivi/conf/layer.conf
+++ b/meta-ivi/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "ivi"
 BBFILE_PATTERN_ivi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_ivi = "7"
-LAYERSERIES_COMPAT_ivi = "thud warrior"
+LAYERSERIES_COMPAT_ivi = "thud warrior hardknott"
 
 # Define a similar VARIABLE to COREBASE in order to get a reference to
 # top directory easily


### PR DESCRIPTION
Assert that meta-ivi is compatible with OE-core/hardnott to support new product development on the latest OE stable branch.